### PR TITLE
[bug] namespace comparison for numpy objects

### DIFF
--- a/datamate/namespaces.py
+++ b/datamate/namespaces.py
@@ -20,7 +20,7 @@ from numpy import ndarray
 from pathlib import Path
 
 import pandas as pd
-
+import numpy as np
 __all__ = ["Namespace", "namespacify", "is_disjoint", "is_subset", "is_superset"]
 
 # -- Namespaces ----------------------------------------------------------------
@@ -542,6 +542,8 @@ def all_true(obj: Any) -> bool:
         return all([all_true(v.item()) for v in obj])
     elif isinstance(obj, Mapping):
         return all([all_true(obj[k]) for k in obj])
+    elif isinstance(obj, np.generic):
+        return bool(obj.item())
     else:
         try:
             return all_true(vars(obj))


### PR DESCRIPTION
Solves the following issue:
```
from datamate import Namespace
import numpy as np

config1 = Namespace(
    a=np.float64(1.0),
)
config2 = Namespace(
    a=1.0,
)
print(config1 == config2)  
```
The comparison raises the error: `TypeError: all True of type <class 'numpy.bool'>: vars() argument must have __dict__ attribute.`

For more details, see discussion in #20 
Closes #20